### PR TITLE
cssBayan

### DIFF
--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -87,6 +87,12 @@ input:checked~label .laber__title {
     font-weight: 800;
     transition: all 0.8s ease-out;
   }
+  .wrapper:hover .laber__plus {
+    color: black;
+    opacity: 1;
+    font-weight: 800;
+    transition: all 0.8s ease-out;
+  }
   .wrapper:hover .laber__title{
     color: black;
     font-weight: 800;

--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -135,3 +135,15 @@ input:checked~label .laber__title {
     font-size: 2.1rem;
   }
 }
+.wrapper__item:active  {
+  opacity: 0.6;
+  transition: 0.5s;
+}
+.wrapper__item:active .laber__title {
+  color: blue;
+  transition: 0.5s;
+}
+.wrapper__item:active .laber__plus {
+  color: blue;
+  transition: 0.5s;
+}

--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -120,7 +120,7 @@ input:checked~label .laber__title {
     width: 50%;
   }
   .wrapper__title {
-    font-size: 3.3rem;
+    font-size: 3.2rem;
   }
   .laber__title {
     font-size: 1.7rem;


### PR DESCRIPTION
1. Task https://github.com/DrDiman/CSS-Bayan-task. 
2. <img width="916" alt="Screenshot at Mar 12 20-39-20" src="https://user-images.githubusercontent.com/113433063/224562333-dc78d0f7-8cb1-4178-bf25-1b0cb4b681e6.png">
3. Deploy - https://naum88.github.io/cssBayan/cssBayan/index.html 
4. Start Date (UTC +03:00) 2023-03-07 03:00 | |  End Date (UTC +03:00) 2023-03-14 02:59. 
5. Score 140/140
- Everything is done from Repository requirements and how to submit task section +30
- The accordion component is centered on the screen, with equal indents on the left and right +10
- Icons, meme texts and meme images are exist +5
- Placement of the meme, icons and meme text are the same as in provided example gif images +5
- Smooth change (transition) of the meme images and icons is done +20
- Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 
320x568, tablet 820x1180, desktop 1920×1080 +10
-  All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is 
 selected are implemented +10
- The entire row (text, icon, and meme image) clickable +5
- Mobile first approach is used - cursor over the memes (hover) effect exists only for desktop devices +10
- The cursor when it is hovering over the rows of the accordion is changing +5
- Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive +10
All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static +5
- Pseudo-elements are not used (note: pseudo-classes are allowed) +5
- Initially, the first meme should be expanded +5
- Font size is changed at each device (mobile, tablet, desktop) +5
6. Отображаються почему то последние три каммита а вот их поный список, по ветке gh-pages. Всего их 9штук
<img width="1744" alt="Screenshot at Mar 13 11-03-36" src="https://user-images.githubusercontent.com/113433063/224942924-08632d26-7eae-48ee-b282-aa409600ff5d.png">









